### PR TITLE
Add support for Hybrid Tables

### DIFF
--- a/src/EFCore.Snowflake/Design/Internal/SnowflakeAnnotationCodeGenerator.cs
+++ b/src/EFCore.Snowflake/Design/Internal/SnowflakeAnnotationCodeGenerator.cs
@@ -48,6 +48,10 @@ public class SnowflakeAnnotationCodeGenerator(AnnotationCodeGeneratorDependencie
         = typeof(SnowflakeTableBuilderExtensions).GetRuntimeMethod(
             nameof(SnowflakeTableBuilderExtensions.IsTransient), [typeof(TableBuilder)])!;
 
+    private static readonly MethodInfo TableIsHybridMethodInfo
+        = typeof(SnowflakeTableBuilderExtensions).GetRuntimeMethod(
+            nameof(SnowflakeTableBuilderExtensions.IsHybrid), [typeof(TableBuilder)])!;
+
     protected override bool IsHandledByConvention(IModel model, IAnnotation annotation)
     {
         if (annotation.Name == SnowflakeAnnotationNames.ValueGenerationStrategy)
@@ -130,6 +134,7 @@ public class SnowflakeAnnotationCodeGenerator(AnnotationCodeGeneratorDependencie
             {
                 SnowflakeTableType.Permanent => TableIsPermanentMethodInfo,
                 SnowflakeTableType.Transient => TableIsTransientMethodInfo,
+                SnowflakeTableType.Hybrid => TableIsHybridMethodInfo,
                 _ => throw new ArgumentOutOfRangeException(nameof(tableType), tableType, null)
             };
 

--- a/src/EFCore.Snowflake/Extensions/SnowflakeTableBuilderExtensions.cs
+++ b/src/EFCore.Snowflake/Extensions/SnowflakeTableBuilderExtensions.cs
@@ -16,4 +16,9 @@ public static class SnowflakeTableBuilderExtensions
     {
         tableBuilder.Metadata.SetTableType(SnowflakeTableType.Transient);
     }
+
+    public static void IsHybrid(this TableBuilder tableBuilder)
+    {
+        tableBuilder.Metadata.SetTableType(SnowflakeTableType.Hybrid);
+    }
 }

--- a/src/EFCore.Snowflake/Metadata/SnowflakeTableType.cs
+++ b/src/EFCore.Snowflake/Metadata/SnowflakeTableType.cs
@@ -3,5 +3,6 @@ namespace EFCore.Snowflake.Metadata;
 public enum SnowflakeTableType
 {
     Permanent,
-    Transient
+    Transient,
+    Hybrid
 }

--- a/src/EFCore.Snowflake/Migrations/SnowflakeMigrationsSqlGenerator.cs
+++ b/src/EFCore.Snowflake/Migrations/SnowflakeMigrationsSqlGenerator.cs
@@ -272,6 +272,7 @@ public class SnowflakeMigrationsSqlGenerator : MigrationsSqlGenerator
         {
             SnowflakeTableType.Permanent => string.Empty,
             SnowflakeTableType.Transient => " TRANSIENT",
+            SnowflakeTableType.Hybrid => " HYBRID",
             _ => throw new ArgumentOutOfRangeException(nameof(tableType), tableType, null)
         };
 

--- a/src/EFCore.Snowflake/Scaffolding/Internal/SnowflakeDatabaseModelFactory.cs
+++ b/src/EFCore.Snowflake/Scaffolding/Internal/SnowflakeDatabaseModelFactory.cs
@@ -240,7 +240,7 @@ WHERE {schemaFilter("SEQUENCE_SCHEMA")}
 
         string query = @$"
 SELECT 
-    TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, IS_TRANSIENT, IS_HYBRID, COMMENT
+    TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, IS_TRANSIENT, COMMENT
 FROM
     INFORMATION_SCHEMA.TABLES
 WHERE
@@ -263,10 +263,11 @@ WHERE
                 comment = reader.GetString("COMMENT");
             }
 
-            bool isTable = tableType == "BASE TABLE";
+            bool isTable = tableType == "BASE TABLE" || tableType == "HYBRID TABLE";
             DatabaseTable table = tableType switch
             {
                 "BASE TABLE" => new DatabaseTable(),
+                "HYBRID TABLE" => new DatabaseTable(),
                 "VIEW" => new DatabaseView(),
                 "MATERIALIZED VIEW" => new DatabaseView(),
                 _ => throw new ArgumentOutOfRangeException($"Unknown table type '{tableType}' when scaffolding {schema}.{tableName}")
@@ -283,7 +284,7 @@ WHERE
                 {
                     innerTableType = SnowflakeTableType.Transient;
                 }
-                else if (string.Equals(reader.GetString("IS_HYBRID"), "HYBRID", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(tableType, "HYBRID TABLE", StringComparison.OrdinalIgnoreCase))
                 {
                     innerTableType = SnowflakeTableType.Hybrid;
                 }

--- a/src/EFCore.Snowflake/Scaffolding/Internal/SnowflakeDatabaseModelFactory.cs
+++ b/src/EFCore.Snowflake/Scaffolding/Internal/SnowflakeDatabaseModelFactory.cs
@@ -240,7 +240,7 @@ WHERE {schemaFilter("SEQUENCE_SCHEMA")}
 
         string query = @$"
 SELECT 
-    TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, IS_TRANSIENT, COMMENT
+    TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, IS_TRANSIENT, IS_HYBRID, COMMENT
 FROM
     INFORMATION_SCHEMA.TABLES
 WHERE
@@ -282,6 +282,10 @@ WHERE
                 if (string.Equals(reader.GetString("IS_TRANSIENT"), "YES", StringComparison.OrdinalIgnoreCase))
                 {
                     innerTableType = SnowflakeTableType.Transient;
+                }
+                else if (string.Equals(reader.GetString("IS_HYBRID"), "HYBRID", StringComparison.OrdinalIgnoreCase))
+                {
+                    innerTableType = SnowflakeTableType.Hybrid;
                 }
 
                 table[SnowflakeAnnotationNames.TableType] = innerTableType;


### PR DESCRIPTION
Snowflake Hybrid Tables (https://docs.snowflake.com/en/user-guide/tables-hybrid) are ideal for use with EF Core given their focus on transactional and low-latency workloads. This PR adds basic support for configuring tables to be created as hybrid tables by specifying the entity.ToTable(t => t.IsHybrid()) flag.