### PR TITLE
Exclude hybrid tables from GetTablesList to fix dotnet scaffolding tool crash

### DIFF
--- a/src/EFCore.Snowflake/Scaffolding/Internal/SnowflakeDatabaseModelFactory.cs
+++ b/src/EFCore.Snowflake/Scaffolding/Internal/SnowflakeDatabaseModelFactory.cs
@@ -258,14 +258,18 @@ WHERE {schemaFilter("SEQUENCE_SCHEMA")}
             ? string.Empty
             : $"AND {tableFilter("TABLE_SCHEMA", "TABLE_NAME")}";
 
+        // Hybrid tables also appear in INFORMATION_SCHEMA.TABLES with TABLE_TYPE = 'BASE TABLE'.
+        // Exclude them here; they are returned with their richer metadata by GetHybridTables.
+        // Without this filter a hybrid table appears twice in the merged list and ToDictionary
+        // throws "An item with the same key has already been added".
         string query = @$"
-SELECT 
+SELECT
     TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, IS_TRANSIENT, COMMENT
 FROM
     INFORMATION_SCHEMA.TABLES
 WHERE
     TABLE_TYPE {tableTypeFilter}
-    
+    AND IS_HYBRID = 'NO'
         {fullTableFilter}
 
         ";


### PR DESCRIPTION
Was getting errors trying to scaffold a DbContext and model classes from a snowflake db that contained hybrid tables. The `dotnet ef dbcontext scaffold` tools would crash when it tried to get the tables from the DB. Looking at the code, I found that the issue was that `SnowflakeDatabaseModelFactory.GetTables()` creates a dictionary using the results of `GetTablesList()` and `GetHybridTables()`, but both of those return the hybrid tables, and so there is a key collision in the Dictionary. This change filters the hybrid tables out of `GetTablesList()` to remove the duplicates.

With these changes the scaffolding tool is able to scaffold hybrid tables.