### PR TITLE
Add Support for Contains/Any/All

### DIFF
--- a/src/EFCore.Snowflake/Query/Internal/SnowflakeSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Snowflake/Query/Internal/SnowflakeSqlTranslatingExpressionVisitor.cs
@@ -5,6 +5,10 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using EFCore.Snowflake.Extensions;
+using EFCore.Snowflake.Storage.Internal.Mapping;
+using EFCore.Snowflake.Utilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -67,7 +71,7 @@ public class SnowflakeSqlTranslatingExpressionVisitor : RelationalSqlTranslating
                 typeof(TimeSpan)
             }
         };
-    
+
     private const char LikeEscapeChar = '\\';
     private const string LikeEscapeCharString = "\\";
 
@@ -151,7 +155,303 @@ public class SnowflakeSqlTranslatingExpressionVisitor : RelationalSqlTranslating
             return translation3;
         }
 
+        if (method.IsGenericMethod
+            && method.GetGenericMethodDefinition() == QueryableMethods.Contains
+            && methodCallExpression.Arguments[0] is MethodCallExpression { Method.Name: nameof(Queryable.AsQueryable) } asQueryableCall
+            && TryTranslateArrayContains(asQueryableCall.Arguments[0], methodCallExpression.Arguments[1], out var arrayContainsTranslation))
+        {
+            return arrayContainsTranslation;
+        }
+
+        if (method.DeclaringType == typeof(Queryable)
+            && (method.Name == nameof(Queryable.Any) || method.Name == nameof(Queryable.All))
+            && methodCallExpression.Arguments.Count == 2
+            && methodCallExpression.Arguments[0] is MethodCallExpression { Method.Name: nameof(Queryable.AsQueryable) } arrayAnyAllSource
+            && TryTranslateArrayElementPredicate(
+                arrayAnyAllSource.Arguments[0], methodCallExpression.Arguments[1], isAny: method.Name == nameof(Queryable.Any),
+                out var arrayAnyAllTranslation))
+        {
+            return arrayAnyAllTranslation;
+        }
+
+        // Parameterless arrayProperty.Any()
+        if (method.DeclaringType == typeof(Queryable)
+            && method.Name == nameof(Queryable.Any)
+            && methodCallExpression.Arguments.Count == 1
+            && methodCallExpression.Arguments[0] is MethodCallExpression { Method.Name: nameof(Queryable.AsQueryable) } arrayAnySource
+            && TryTranslateArrayAny(arrayAnySource.Arguments[0], out var arrayAnyTranslation))
+        {
+            return arrayAnyTranslation;
+        }
+
         return base.VisitMethodCall(methodCallExpression);
+    }
+
+    private bool TryTranslateArrayAny(Expression collectionAccessExpression, [NotNullWhen(true)] out SqlExpression? translation)
+    {
+        if (Visit(collectionAccessExpression) is not SqlExpression arrayColumn)
+        {
+            translation = null;
+            return false;
+        }
+
+        SqlExpression arraySize = _sqlExpressionFactory.Function(
+            "ARRAY_SIZE",
+            new[] { arrayColumn },
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[1],
+            typeof(int));
+
+        SqlExpression sizeGreaterThanZero = _sqlExpressionFactory.GreaterThan(arraySize, _sqlExpressionFactory.Constant(0));
+
+        SqlExpression nvl = _sqlExpressionFactory.Function(
+            "NVL",
+            new[] { sizeGreaterThanZero, _sqlExpressionFactory.Constant(false) },
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[2],
+            typeof(bool));
+
+        translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(nvl);
+        return true;
+    }
+
+    private bool TryTranslateArrayElementPredicate(
+        Expression collectionAccessExpression,
+        Expression predicateExpression,
+        bool isAny,
+        [NotNullWhen(true)] out SqlExpression? translation)
+    {
+        translation = null;
+
+        (Type? entityClrType, string? propertyName) = collectionAccessExpression switch
+        {
+            MethodCallExpression { Method.Name: nameof(EF.Property) } efPropertyCall
+                when efPropertyCall.Arguments[1] is ConstantExpression { Value: string name }
+                => (efPropertyCall.Arguments[0].Type, name),
+            MemberExpression { Expression: not null } memberExpression
+                => (memberExpression.Expression.Type, memberExpression.Member.Name),
+            _ => (null, null)
+        };
+
+        if (entityClrType is null || propertyName is null)
+        {
+            return false;
+        }
+
+        IEntityType? entityType = _queryCompilationContext.Model.FindEntityType(entityClrType);
+        IProperty? arrayProperty = entityType?.FindProperty(propertyName);
+        IReadOnlyList<IProperty>? primaryKeyProperties = entityType?.FindPrimaryKey()?.Properties;
+
+        // This translation strategy needs a single-column primary key to correlate the derived table back to the
+        // entity being queried; composite keys and keyless entities aren't supported here.
+        // TODO: support composite primary keys (group by / row-value IN on all key columns).
+        if (entityType is null || arrayProperty is null || primaryKeyProperties is not { Count: 1 })
+        {
+            return false;
+        }
+
+        string? table = entityType.GetTableName();
+        string? arrayColumn = arrayProperty.GetColumnName();
+        string? pkColumn = primaryKeyProperties[0].GetColumnName();
+        if (table is null || arrayColumn is null || pkColumn is null)
+        {
+            return false;
+        }
+
+        if (predicateExpression is not UnaryExpression { Operand: LambdaExpression lambda }
+            || lambda.Body is not MethodCallExpression
+            {
+                Method: { Name: nameof(string.Contains) or nameof(string.StartsWith) or nameof(string.EndsWith) }
+            } predicateCall
+            || predicateCall.Object != lambda.Parameters[0]
+            || predicateCall.Arguments.Count != 1)
+        {
+            return false;
+        }
+
+        StartsEndsWithContains predicateType = predicateCall.Method.Name switch
+        {
+            nameof(string.StartsWith) => StartsEndsWithContains.StartsWith,
+            nameof(string.EndsWith) => StartsEndsWithContains.EndsWith,
+            _ => StartsEndsWithContains.Contains
+        };
+
+        if (!TryBuildLikePattern(predicateCall.Arguments[0], predicateType, out SqlExpression? likePattern))
+        {
+            return false;
+        }
+
+        SqlExpression? arrayColumnForEmptyCheck = isAny ? null : Visit(collectionAccessExpression) as SqlExpression;
+        if (!isAny && arrayColumnForEmptyCheck is null)
+        {
+            return false;
+        }
+
+        string quotedSchema = entityType.GetSchema() is { } schema
+            ? $"{QuoteIdentifier(schema)}.{QuoteIdentifier(table)}"
+            : QuoteIdentifier(table);
+        string quotedArrayColumn = QuoteIdentifier(arrayColumn);
+        string quotedPkColumn = QuoteIdentifier(pkColumn);
+
+        const string outerAlias = "flt_src";
+        const string flattenAlias = "flt_elem";
+
+        SqlExpression elementValue = _sqlExpressionFactory.Fragment($"{flattenAlias}.\"VALUE\"::STRING");
+        SqlExpression elementPredicate = _sqlExpressionFactory.Like(
+            elementValue, likePattern, _sqlExpressionFactory.Constant(LikeEscapeCharString));
+
+        // For All(predicate), an element fails the condition when the predicate is false; count those instead.
+        if (!isAny)
+        {
+            elementPredicate = _sqlExpressionFactory.Not(elementPredicate);
+        }
+
+        SqlExpression countIf = _sqlExpressionFactory.Function(
+            "COUNT_IF",
+            new[] { elementPredicate },
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[1],
+            typeof(int));
+
+        SqlExpression havingCondition = isAny
+            ? _sqlExpressionFactory.NotEqual(countIf, _sqlExpressionFactory.Constant(0))
+            : _sqlExpressionFactory.Equal(countIf, _sqlExpressionFactory.Constant(0));
+
+        string subquerySqlPrefix =
+            $"SELECT {outerAlias}.{quotedPkColumn} " +
+            $"FROM {quotedSchema} AS {outerAlias}, LATERAL FLATTEN(INPUT => {outerAlias}.{quotedArrayColumn}) AS {flattenAlias} " +
+            $"GROUP BY {outerAlias}.{quotedPkColumn} HAVING";
+
+        SqlExpression subquery = _sqlExpressionFactory.Function(
+            subquerySqlPrefix,
+            new[] { havingCondition },
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[1],
+            typeof(bool));
+
+        SqlExpression inExpression = _sqlExpressionFactory.Function(
+            $"{quotedPkColumn} IN",
+            new[] { subquery },
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[1],
+            typeof(bool));
+
+        // Guard against NULL from the IN check (e.g. no rows at all) so this always evaluates to a proper boolean.
+        SqlExpression nvl = _sqlExpressionFactory.Function(
+            "NVL",
+            new[] { inExpression, _sqlExpressionFactory.Constant(false) },
+            nullable: true,
+            argumentsPropagateNullability: Statics.TrueArrays[2],
+            typeof(bool));
+
+        SqlExpression result = nvl;
+
+        if (!isAny && arrayColumnForEmptyCheck is not null)
+        {
+            SqlExpression arraySize = _sqlExpressionFactory.Function(
+                "ARRAY_SIZE",
+                new[] { arrayColumnForEmptyCheck },
+                nullable: true,
+                argumentsPropagateNullability: Statics.TrueArrays[1],
+                typeof(int));
+
+            SqlExpression arrayIsEmptyOrNull = _sqlExpressionFactory.OrElse(
+                _sqlExpressionFactory.IsNull(arrayColumnForEmptyCheck),
+                _sqlExpressionFactory.Equal(arraySize, _sqlExpressionFactory.Constant(0)));
+
+            result = _sqlExpressionFactory.OrElse(arrayIsEmptyOrNull, nvl);
+        }
+
+        translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(result);
+        return true;
+    }
+
+    private bool TryBuildLikePattern(
+        Expression patternValueExpression,
+        StartsEndsWithContains methodType,
+        [NotNullWhen(true)] out SqlExpression? likePattern)
+    {
+        if (Visit(patternValueExpression) is not SqlExpression visited)
+        {
+            likePattern = null;
+            return false;
+        }
+
+        switch (visited)
+        {
+            case SqlConstantExpression { Value: string s }:
+                likePattern = _sqlExpressionFactory.ApplyDefaultTypeMapping(
+                    _sqlExpressionFactory.Constant(BuildLikePatternText(s, methodType)));
+                return true;
+
+            case SqlParameterExpression patternParameter:
+            {
+                var lambda = Expression.Lambda(
+                    Expression.Call(
+                        EscapeLikePatternParameterMethod,
+                        QueryCompilationContext.QueryContextParameter,
+                        Expression.Constant(patternParameter.Name),
+                        Expression.Constant(methodType)),
+                    QueryCompilationContext.QueryContextParameter);
+
+                var escapedPatternParameter =
+                    _queryCompilationContext.RegisterRuntimeParameter(
+                        $"{patternParameter.Name}_{methodType.ToString().ToLower(CultureInfo.InvariantCulture)}", lambda);
+
+                likePattern = new SqlParameterExpression(
+                    escapedPatternParameter.Name!, escapedPatternParameter.Type, Dependencies.TypeMappingSource.FindMapping(typeof(string)));
+                return true;
+            }
+
+            default:
+                likePattern = null;
+                return false;
+        }
+    }
+
+    private static string BuildLikePatternText(string pattern, StartsEndsWithContains methodType)
+        => methodType switch
+        {
+            StartsEndsWithContains.StartsWith => EscapeLikePattern(pattern) + '%',
+            StartsEndsWithContains.EndsWith => '%' + EscapeLikePattern(pattern),
+            StartsEndsWithContains.Contains => $"%{EscapeLikePattern(pattern)}%",
+            _ => throw new ArgumentOutOfRangeException(nameof(methodType), methodType, null)
+        };
+
+    private static string QuoteIdentifier(string name) => $"\"{name.Replace("\"", "\"\"")}\"";
+
+    private bool TryTranslateArrayContains(
+        Expression collectionExpression,
+        Expression valueExpression,
+        [NotNullWhen(true)] out SqlExpression? translation)
+    {
+        if (Visit(collectionExpression) is SqlExpression collection
+            && Visit(valueExpression) is SqlExpression value)
+        {
+            value = _sqlExpressionFactory.ApplyDefaultTypeMapping(value);
+
+            // Array elements are stored as VARIANT, so the searched value must be cast to VARIANT to compare equal.
+            SqlExpression valueAsVariant = _sqlExpressionFactory.Function(
+                "TO_VARIANT",
+                new[] { value },
+                nullable: true,
+                argumentsPropagateNullability: Statics.TrueArrays[1],
+                typeof(object),
+                SnowflakeVariantTypeMapping.Default);
+
+            SqlExpression arrayContains = _sqlExpressionFactory.Function(
+                "ARRAY_CONTAINS",
+                new[] { valueAsVariant, collection },
+                nullable: true,
+                argumentsPropagateNullability: Statics.TrueArrays[2],
+                returnType: typeof(bool));
+
+            translation = _sqlExpressionFactory.ApplyDefaultTypeMapping(arrayContains);
+            return true;
+        }
+
+        translation = null;
+        return false;
     }
 
     private Expression TranslateByteArrayElementAccess(Expression array, Expression index, Type resultType)

--- a/test/EFCore.Snowflake.FunctionalTests/Query/ArrayQueryTest.cs
+++ b/test/EFCore.Snowflake.FunctionalTests/Query/ArrayQueryTest.cs
@@ -52,12 +52,211 @@ public class ArrayQueryTest : IClassFixture<ArrayQueryTest.ArrayQueryFixture>
         Assert.False(item.BoolArray[2]!.Value);
     }
 
+    [ConditionalFact]
+    public virtual void Where_Array_Contains_Constant()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableItem item = context.TableItems.Single(i => i.StringArray.Contains("CCCC"));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Contains_Parameter()
+    {
+        using ArrayQueryContext context = CreateContext();
+        string value = "B";
+        TableItem item = context.TableItems.Single(i => i.StringArray.Contains(value));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Contains_Missing_Value_Returns_No_Results()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableItems.Any(i => i.StringArray.Contains("does-not-exist"));
+        Assert.False(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Int_Array_Contains_Constant()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableItem item = context.TableItems.Single(i => i.IntArray.Contains(4));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_List_Contains_Constant()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableItem item = context.TableItems.Single(i => i.StringList.Contains("CCCC"));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Nullable_Element_Array_Contains_Constant()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableItemNullable item = context.TableItemNullables.Single(i => i.IntArray.Contains(4));
+        Assert.Equal(1, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Contains_On_Nullable_Column()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableColumnNullable item = context.TableColumnNullables.Single(i => i.StringArray!.Contains("a"));
+        Assert.Equal(1, item.Id);
+
+        bool anyMatchOnNullColumn = context.TableColumnNullables
+            .Where(i => i.Id == 2)
+            .Any(i => i.StringArray!.Contains("a"));
+        Assert.False(anyMatchOnNullColumn);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Contains_Constant()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableItem item = context.TableItems.Single(i => i.StringArray.Any(a => a.Contains("CC")));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Contains_Parameter()
+    {
+        using ArrayQueryContext context = CreateContext();
+        string pattern = "CC";
+        TableItem item = context.TableItems.Single(i => i.StringArray.Any(a => a.Contains(pattern)));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_StartsWith_Missing_Returns_No_Results()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableItems.Any(i => i.StringArray.Any(a => a.StartsWith("zzz")));
+        Assert.False(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Contains_Escapes_Special_Characters()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableItems.Any(i => i.StringArray.Any(a => a.Contains("5_")));
+        Assert.False(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_All_Contains_Empty_Pattern_Matches_All_Elements()
+    {
+        using ArrayQueryContext context = CreateContext();
+        TableItem item = context.TableItems.Single(i => i.StringArray.All(a => a.Contains("")));
+        Assert.Equal(1000, item.Id);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_All_StartsWith_Not_All_Match_Returns_No_Results()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableItems.Any(i => i.StringArray.All(a => a.StartsWith("a")));
+        Assert.False(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_All_On_Empty_Array_Is_Vacuously_True()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool clientSideAll = Array.Empty<string>().All(a => a.StartsWith("a"));
+        Assert.True(clientSideAll);
+
+        TableColumnNullable item = context.TableColumnNullables.Single(i => i.Id == 3);
+        Assert.NotNull(item.StringArray);
+        Assert.Empty(item.StringArray);
+
+        bool dbSideAll = context.TableColumnNullables
+            .Any(i => i.Id == 3 && i.StringArray!.All(a => a.StartsWith("a")));
+
+        Assert.Equal(clientSideAll, dbSideAll);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_All_On_Null_Array_Is_Vacuously_True()
+    {
+        using ArrayQueryContext context = CreateContext();
+
+        TableColumnNullable item = context.TableColumnNullables.Single(i => i.Id == 2);
+        Assert.Null(item.StringArray);
+
+        bool dbSideAll = context.TableColumnNullables
+            .Any(i => i.Id == 2 && i.StringArray!.All(a => a.StartsWith("a")));
+
+        Assert.True(dbSideAll);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Parameterless_On_NonEmpty_Array_Is_True()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableItems.Any(i => i.StringArray.Any());
+        Assert.True(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Parameterless_On_Empty_Array_Is_False()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableColumnNullables.Any(i => i.Id == 3 && i.StringArray!.Any());
+        Assert.False(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Parameterless_On_Null_Array_Is_False()
+    {
+        using ArrayQueryContext context = CreateContext();
+        bool any = context.TableColumnNullables.Any(i => i.Id == 2 && i.StringArray!.Any());
+        Assert.False(any);
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Compound_Predicate_Is_Not_Supported()
+    {
+        using ArrayQueryContext context = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => context.TableItems.Any(i => i.StringArray.Any(a => a.StartsWith("a") && a.EndsWith("b"))));
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Non_String_Method_Predicate_Is_Not_Supported()
+    {
+        using ArrayQueryContext context = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => context.TableItems.Any(i => i.StringArray.Any(a => a.Length > 2)));
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Nested_Member_Chain_Predicate_Is_Not_Supported()
+    {
+        using ArrayQueryContext context = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => context.TableItems.Any(i => i.StringArray.Any(a => a.ToUpper().Contains("A"))));
+    }
+
+    [ConditionalFact]
+    public virtual void Where_Array_Any_Chained_Before_Predicate_Is_Not_Supported()
+    {
+        using ArrayQueryContext context = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => context.TableItems.Any(i => i.StringArray.Where(a => a.Length > 1).Any()));
+    }
+
     protected ArrayQueryContext CreateContext() => Fixture.CreateContext();
 
     public class TableItem
     {
         public long Id { get; set; }
         public string[] StringArray { get; set; } = null!;
+        public List<string> StringList { get; set; } = null!;
         public bool[] BoolArray { get; set; } = null!;
         public char[] CharArray { get; set; } = null!;
         public byte[][] ByteArrayArray { get; set; } = null!;
@@ -150,7 +349,8 @@ public class ArrayQueryTest : IClassFixture<ArrayQueryTest.ArrayQueryFixture>
             context.AddRange(new TableItem()
             {
                 Id = 1000,
-                StringArray = ["a", "B", "CCCC"],
+                StringArray = ["a", "B", "CCCC", "5\\X"],
+                StringList = ["a", "B", "CCCC"],
                 BoolArray = [true, false],
                 ByteArrayArray = [ [0,1], [2, 255] ],
                 CharArray = ['a', 'B', '\\'],
@@ -196,6 +396,11 @@ public class ArrayQueryTest : IClassFixture<ArrayQueryTest.ArrayQueryFixture>
             new TableColumnNullable()
             {
                 Id = 2
+            },
+            new TableColumnNullable()
+            {
+                Id = 3,
+                StringArray = []
             },
             new TableItemNullable()
             {


### PR DESCRIPTION
This PR Adds support for querying array/collection columns with `Contains`, `Any`, and `Any(predicate)`/`All(predicate)`.                                                                                              
                                                                                                                                                                                                                 
  - `arr.Contains(value)` → `ARRAY_CONTAINS(...)`                                                                                                                                                                
  - `arr.Any()` → `ARRAY_SIZE(...) > 0`                                                                                                                                                                          
  - `arr.Any(a => a.Contains/StartsWith/EndsWith(x))` / `.All(...)` → non-correlated `IN (SELECT ... GROUP BY ... HAVING COUNT_IF(...))`, since Snowflake doesn't support the correlated `EXISTS + LATERAL       
  FLATTEN` shape EF Core normally generates for this                                                                                                                                                             
  - `All()` correctly returns `true` for empty/null arrays (matches LINQ semantics)                                                                                                                              
                                                                                                                                                                                                                 
  Known limitations (all fail loudly, not silently wrong):                                                                                                                                                       
  - `Any`/`All` predicates: only `StartsWith`/`EndsWith`/`Contains` on string elements, no compound predicates or chained LINQ before them                                                                       
  - `Any`/`All` needs a single-column primary key (composite/keyless entities unsupported)                                                                                                                       
                                                                                                                                                                                                                 
  Tested against a live Snowflake instance (25 tests in `ArrayQueryTest`).  